### PR TITLE
Doubles shotty pellets

### DIFF
--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3256,6 +3256,7 @@
 #include "hippiestation\code\modules\projectiles\ammunition\ammo_casings.dm"
 #include "hippiestation\code\modules\projectiles\ammunition\energy.dm"
 #include "hippiestation\code\modules\projectiles\ammunition\magazines.dm"
+#include "hippiestation\code\modules\projectiles\ammunition\ballistic\shotgun.dm"
 #include "hippiestation\code\modules\projectiles\boxes_magazines\ammo_boxes.dm"
 #include "hippiestation\code\modules\projectiles\boxes_magazines\external_mag.dm"
 #include "hippiestation\code\modules\projectiles\guns\grenade_launcher.dm"

--- a/hippiestation/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/hippiestation/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -1,0 +1,5 @@
+/obj/item/ammo_casing/shotgun/buckshot
+	pellets = 12
+
+/obj/item/ammo_casing/shotgun/rubbershot
+	pellets = 12

--- a/hippiestation/code/modules/projectiles/projectile/bullets.dm
+++ b/hippiestation/code/modules/projectiles/projectile/bullets.dm
@@ -23,3 +23,10 @@
 /obj/item/projectile/bullet/p50 // Sniper rifles
 	stun = 10
 	paralyze = 10
+	
+/obj/item/projectile/bullet/pellet/shotgun_buckshot
+	damage = 6.25
+
+/obj/item/projectile/bullet/pellet/shotgun_rubbershot
+	damage = 1.5
+	stamina = 12.5


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs )

:cl: YoYoBatty
balance: Halves damage of rubber and buckshot but doubles pellets.
balance: Increases velocity of shotgun rubber and buckshot pellets.
/:cl:

[why]: 